### PR TITLE
Game start/end deadzone trigger bug fix

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -163,6 +163,7 @@ export default class Engine {
     // Player has reached end
     if (this.game.end.collides(this.game.player)[0]) {
       audio.win()
+      // TODO - Trigger game end animation
       dispatcher(this.canvas, EVENTS.LEVEL_COMPLETE)
     } else {
       this.game.end.draw()

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -44,8 +44,9 @@ const map = (canvas, context, levelIndex = 1) => {
   })
 
   // Add deadzone
-  for(let i = 0; i < currentLevel[levelIndex].length; i ++) {
-    obstacles.push(deadzone(i * size, canvas.height + 50, size))
+  // Add 5 units of buffer at the end of the game and at the start of the game
+  for(let i = -5; i < currentLevel[levelIndex].length + 5; i ++) {
+    obstacles.push(deadzone(i * size, canvas.height + 50, size, 1))
   }
 
 


### PR DESCRIPTION
bug-fix(game doesn't end at start and end of level): Add 5 unit buffer at the start and end of each level.

**Note:** We may need to add more that the end of the level if they jump from the top of the map lol.